### PR TITLE
fix: use correct method names for memcached module

### DIFF
--- a/src/memcached-store.ts
+++ b/src/memcached-store.ts
@@ -20,7 +20,7 @@ export default class MemcachedStore {
   }
 
   public incr(key: string, cb: any): void {
-    this.client.increment(`${this.prefix}${key}`, 1, (err: any, result: boolean|number) => {
+    this.client.incr(`${this.prefix}${key}`, 1, (err: any, result: boolean|number) => {
       if (err) { return cb(err, undefined) }
 
       if (result === false) {
@@ -38,7 +38,7 @@ export default class MemcachedStore {
   }
 
   public decrement(key: string): void {
-    this.client.decrement(`${this.prefix}${key}`, 1, (err: any, result: boolean|number) => {
+    this.client.decr(`${this.prefix}${key}`, 1, (err: any, result: boolean|number) => {
       return { err, result }
     })
   }


### PR DESCRIPTION
The memcached module provides aliases increment and decrement for incr
and decr but they are not documented and not part of the TypeScript type
definitions.

This updates the rate limit store to use the documented method names.
This means the rate limiter code can be more easily tested using a mock
memcached client.